### PR TITLE
Fixed data.json endpoint to export only first group as publisher.

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,12 +3,18 @@ Open Data Schema Map DKAN
 
 Default Open Data Schema Map endpoints for DKAN. Includes CKAN and Project Open Data endpoints.
 
-Includes the following endpoints:
+## Project Open Data
 
-#### Project Open Data
-* data.json
+Provides default mappings between DKAN and POD's [data.json](https://project-open-data.cio.gov/v1.1/schema/).
 
-#### CKAN
+### Notes
+
+* The ["name" field on data.json's "publisher" object](https://project-open-data.cio.gov/v1.1/schema/#publisher) maps to a dataset's group (see [Organic Groups](https://www.drupal.org/project/og)) in DKAN. Note that while it is possible to assign a dataset to multiple groups in DKAN, data.json only allows for a single publisher. If a dataset belongs to multiple groups, only the first group will be exposed as the "publisher" in data.json
+
+## CKAN
+
+Provides endpoints for publishing via the [CKAN API](http://docs.ckan.org/en/latest/api/)
+
 * ckan_package_show
 * ckan_current_package_list_with_resources
 * ckan_group_list

--- a/open_data_schema_map_dkan.features.inc
+++ b/open_data_schema_map_dkan.features.inc
@@ -1652,7 +1652,7 @@ function open_data_schema_map_dkan_open_data_schema_apis_defaults() {
         'type' => 'array',
       ),
       'publisher' => array(
-        'value' => '[node:og_group_ref]',
+        'value' => '[node:og_group_ref:0]',
         'type' => 'string',
       ),
       'references' => array(
@@ -1828,7 +1828,7 @@ function open_data_schema_map_dkan_open_data_schema_apis_defaults() {
           'type' => '',
         ),
         'name' => array(
-          'value' => '[node:og_group_ref]',
+          'value' => '[node:og_group_ref:0]',
           'type' => '',
         ),
         'subOrganizationOf' => array(


### PR DESCRIPTION
Ref: https://github.com/NuCivic/dkan_harvest/pull/29

If there is more than one group associated with a dataset only one group should be exposed on the 'name' field in the 'publisher' section in data.json.